### PR TITLE
Update extraParams.hxml

### DIFF
--- a/extraParams.hxml
+++ b/extraParams.hxml
@@ -1,1 +1,2 @@
 --macro db.macros.Library.printInfo()
+-D dbcore


### PR DESCRIPTION
Just added a `dbcore` define, when hopping around haxe versions I get inconsistent parsing of the `#if db_core` define, just wanted to remove the underscore from equation